### PR TITLE
Bare Metal LLVM Compile Fix

### DIFF
--- a/src/ewf_platform_bare_metal.h
+++ b/src/ewf_platform_bare_metal.h
@@ -16,6 +16,7 @@
 #endif
 
 #include <stdint.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Add `<stdlib.h>` include for bare metal.